### PR TITLE
Allow the API key and secret to be passed in as command-line arguments and be stored in the object

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,3 +27,6 @@ out a way to display the output publicly at some point.
 * `--period` : The time period for the stats. Can be "overall", "7day", "1month", "3month", "6month", "12month" (defaults to "7day")
 * `--api-key` : Last.fm API key
 * `--api-secret` : Last.fm API secret
+
+The values for `--api-key` and `--api-secret` can alternatively be read from
+environment variables called `LASTFM_API_KEY` and `LASTFM_API_SECRET`.

--- a/README.md
+++ b/README.md
@@ -25,3 +25,5 @@ out a way to display the output publicly at some point.
 * `--count` : The number of artists to display (defaults to 10)
 * `--format` : The format to display results in. Can be "text", "html" or "json" (defaults to "text")
 * `--period` : The time period for the stats. Can be "overall", "7day", "1month", "3month", "6month", "12month" (defaults to "7day")
+* `--api-key` : Last.fm API key
+* `--api-secret` : Last.fm API secret

--- a/lib/App/LastStats.pm
+++ b/lib/App/LastStats.pm
@@ -16,9 +16,11 @@ class App::LastStats {
   field $period   :param = '7day';
   field $format   :param = 'text';
   field $count    :param = 10;
+  field $api_key  :param = $ENV{LASTFM_API_KEY};
+  field $api_secret :param = $ENV{LASTFM_SECRET};
   field $lastfm   = Net::LastFM->new(
-    api_key    => $ENV{LASTFM_API_KEY},
-    api_secret => $ENV{LASTFM_SECRET},
+    api_key    => $api_key,
+    api_secret => $api_secret,
   );
   field $method   = 'user.getTopArtists';
   field $data;
@@ -32,10 +34,12 @@ class App::LastStats {
 
   method run {
     GetOptions(
-      'user=s'   => \$username,
-      'period=s' => \$period,
-      'format=s' => \$format,
-      'count=i'  => \$count,
+      'user=s'      => \$username,
+      'period=s'    => \$period,
+      'format=s'    => \$format,
+      'count=i'     => \$count,
+      'api-key=s'   => \$api_key,
+      'api-secret=s'=> \$api_secret,
     );
 
     $self->validate;
@@ -119,10 +123,12 @@ App::LastStats - A module to fetch and display Last.fm statistics
   use App::LastStats;
 
   my $stats = App::LastStats->new(
-    username => 'davorg',
-    period   => '7day',
-    format   => 'text',
-    count    => 10,
+    username   => 'davorg',
+    period     => '7day',
+    format     => 'text',
+    count      => 10,
+    api_key    => 'your_api_key',
+    api_secret => 'your_api_secret',
   );
 
   $stats->run;

--- a/lib/App/LastStats.pm
+++ b/lib/App/LastStats.pm
@@ -12,13 +12,13 @@ class App::LastStats {
 
   our $VERSION = '0.0.3';
 
-  field $username :param = 'davorg';
-  field $period   :param = '7day';
-  field $format   :param = 'text';
-  field $count    :param = 10;
-  field $api_key  :param = $ENV{LASTFM_API_KEY};
-  field $api_secret :param = $ENV{LASTFM_SECRET};
-  field $lastfm   = Net::LastFM->new(
+  field $username   :param = 'davorg';
+  field $period     :param = '7day';
+  field $format     :param = 'text';
+  field $count      :param = 10;
+  field $api_key    :param = $ENV{LASTFM_API_KEY};
+  field $api_secret :param = $ENV{LASTFM_API_SECRET};
+  field $lastfm     = Net::LastFM->new(
     api_key    => $api_key,
     api_secret => $api_secret,
   );

--- a/t/01-basic.t
+++ b/t/01-basic.t
@@ -1,11 +1,6 @@
 use Test::More;
 use App::LastStats;
 
-# These are only useful while we're not actually making
-# API calls
-$ENV{LASTFM_API_KEY} = 'SomeRandomKey';
-$ENV{LASTFM_SECRET}  = 'Sekrit';
-
 my $stats = App::LastStats->new(
     username => 'davorg',
     period   => '7day',
@@ -20,21 +15,18 @@ ok($stats, 'Object created');
 ok($stats->can('laststats'), 'Method laststats exists');
 ok($stats->can('render'), 'Method render exists');
 
-# Test command-line options for API key and secret
-my $stats_with_options = App::LastStats->new(
+# These are only useful while we're not actually making
+# API calls
+$ENV{LASTFM_API_KEY}     = 'SomeRandomKey';
+$ENV{LASTFM_API_SECRET}  = 'Sekrit';
+
+$stats = App::LastStats->new(
     username => 'davorg',
     period   => '7day',
     format   => 'text',
     count    => 10,
 );
 
-Getopt::Long::Configure("pass_through");
-GetOptions(
-    'api-key=s'   => \$stats_with_options->{api_key},
-    'api-secret=s'=> \$stats_with_options->{api_secret},
-);
-
-ok($stats_with_options->{api_key} eq 'SomeRandomKey', 'API key set from command-line option');
-ok($stats_with_options->{api_secret} eq 'Sekrit', 'API secret set from command-line option');
+ok($stats, 'Get API details from environment');
 
 done_testing;

--- a/t/01-basic.t
+++ b/t/01-basic.t
@@ -11,11 +11,30 @@ my $stats = App::LastStats->new(
     period   => '7day',
     format   => 'text',
     count    => 10,
+    api_key  => 'SomeRandomKey',
+    api_secret => 'Sekrit',
 );
 
 ok($stats, 'Object created');
 
 ok($stats->can('laststats'), 'Method laststats exists');
 ok($stats->can('render'), 'Method render exists');
+
+# Test command-line options for API key and secret
+my $stats_with_options = App::LastStats->new(
+    username => 'davorg',
+    period   => '7day',
+    format   => 'text',
+    count    => 10,
+);
+
+Getopt::Long::Configure("pass_through");
+GetOptions(
+    'api-key=s'   => \$stats_with_options->{api_key},
+    'api-secret=s'=> \$stats_with_options->{api_secret},
+);
+
+ok($stats_with_options->{api_key} eq 'SomeRandomKey', 'API key set from command-line option');
+ok($stats_with_options->{api_secret} eq 'Sekrit', 'API secret set from command-line option');
 
 done_testing;


### PR DESCRIPTION
Related to #10

Add command-line options for API key and secret, and store them in the object.

* **lib/App/LastStats.pm**
  - Add `api_key` and `api_secret` fields to the `App::LastStats` class.
  - Update the `GetOptions` function to include `--api-key` and `--api-secret` options.
  - Update the `Net::LastFM` object instantiation to use the `api_key` and `api_secret` fields.
  - Update the `SYNOPSIS` section in the POD documentation to include the new options.

* **README.md**
  - Add documentation for the new command-line options `--api_key` and `--api_secret`.

* **t/01-basic.t**
  - Add tests for the new command-line options `--api_key` and `--api_secret`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/davorg-cpan/app-laststats/issues/10?shareId=2b1aaf62-6dda-491b-bc78-c039d6d34b69).